### PR TITLE
Fix compilation error: iwl_fw_runtime has no member named geo_enabled

### DIFF
--- a/iwlwifi-stack-dev/drivers/net/wireless/intel/iwlwifi/fw/uefi.c
+++ b/iwlwifi-stack-dev/drivers/net/wireless/intel/iwlwifi/fw/uefi.c
@@ -315,8 +315,10 @@ void iwl_uefi_get_sgom_table(struct iwl_trans *trans,
 	unsigned long package_size;
 	int err, ret;
 
+	#ifdef CONFIG_ACPI
 	if (!fwrt->geo_enabled)
 		return;
+	#endif
 
 	sgom_efivar = kzalloc(sizeof(*sgom_efivar), GFP_KERNEL);
 	if (!sgom_efivar)


### PR DESCRIPTION
Fixes https://github.com/intel/backport-iwlwifi/issues/16